### PR TITLE
popravi dead link

### DIFF
--- a/content/events.json
+++ b/content/events.json
@@ -101,7 +101,7 @@
   },
   {
     "title": "Bitcoin only meetup in Belgrade 🍻🇷🇸",
-    "url": "https://www.meetup.com/dvadeset-jedan/events/cpwpvsydcqbsb/",
+    "url": "https://www.meetup.com/dvadeset-jedan/events/",
     "date": "2022-12-14",
     "venue": "Dogma Brewery & Tap Room",
     "address": "Radnička 3, Čukarica Beograd",


### PR DESCRIPTION
Privremeni nacin da se popravi deadlink na mapi, dugorocno moramo naci bolje resenje za meetupe.